### PR TITLE
feat: decorations for .umirc config

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,17 @@
     }
   },
   "contributes": {
+    "colors": [
+      {
+        "id": "umipro.annotationColor",
+        "description": "text color of line annotations",
+        "defaults": {
+          "dark": "#99999950",
+          "light": "#999999A6",
+          "highContrast": "#99999999"
+        }
+      }
+    ],
     "configuration": {
       "type": "object",
       "title": "Umi Pro configuration",

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,4 +1,5 @@
 import { ParserOptions } from '@babel/parser';
+import { SourceLocation } from '@babel/types';
 
 export enum QuoteType {
   double = 'double',
@@ -52,6 +53,13 @@ export interface IDvaModel {
 
 export interface IDvaModelWithFilePath extends IDvaModel {
   filePath: string;
+}
+
+export interface IUmirc {
+  key: string;
+  loc: SourceLocation;
+  start: number;
+  end: number;
 }
 
 export enum Brackets {

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -49,3 +49,12 @@ export function isUndefined<T>(data: T | undefined): data is T {
   // eslint-disable-next-line no-undefined
   return data === undefined;
 }
+
+export function isNotNull<T>(data: T | null): data is T {
+  // eslint-disable-next-line no-undefined
+  return data !== null;
+}
+
+export function duplicateUnicodeCharacter(str: string, num: number) {
+  return new Array(num).fill(str).join('');
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import { workspace, languages } from 'vscode';
+import { workspace, languages, ExtensionContext } from 'vscode';
 import 'reflect-metadata';
 import { Container } from 'typedi';
 import {
@@ -7,6 +7,7 @@ import {
   ModelActionReference,
   ActionTypeCompletionItemProvider,
 } from './language/model';
+import { UmircDecoration } from './language/umircDecoration';
 import { UmiRouterCompletionItemProvider, UmiRouterDefinitionProvider } from './language/router';
 import logger from './common/logger';
 import { getUmiFileWatcher } from './common/fileWatcher';
@@ -14,7 +15,7 @@ import { loadVscodeService, VscodeServiceToken } from './services/vscodeService'
 import { ModelInfoServiceToken } from './services/modelInfoService';
 import { SUPPORT_LANGUAGE } from './common/types';
 
-export async function activate(context) {
+export async function activate(context: ExtensionContext) {
   logger.info('extension "umi-pro" is now active!');
   const umiFileWatcher = await getUmiFileWatcher(workspace.workspaceFolders);
   if (!umiFileWatcher) {
@@ -65,6 +66,8 @@ export async function activate(context) {
   context.subscriptions.push(
     languages.registerReferenceProvider(SUPPORT_LANGUAGE, Container.get(ModelActionReference))
   );
+
+  context.subscriptions.push(Container.get(UmircDecoration));
 }
 
 export function deactivate() {}

--- a/src/language/umircDecoration/index.ts
+++ b/src/language/umircDecoration/index.ts
@@ -11,11 +11,12 @@ import {
 import { basename } from 'path';
 import { isNotNull } from '../../common/utils';
 import { IUmircParser, UmircParserToken } from '../../services/parser/umircParser';
-import umircDef from './umircDef';
+import { getlang } from './umircDef';
 
 @Service()
 export class UmircDecoration implements Disposable {
   private umircParser: IUmircParser;
+  private lang: object = getlang();
 
   private annotationDecoration = window.createTextEditorDecorationType({});
 
@@ -48,7 +49,7 @@ export class UmircDecoration implements Disposable {
       const umiProperties = await this.umircParser.parseFile(document.fileName);
       const decorations: Array<DecorationOptions> = umiProperties
         .map(p => {
-          if (!umircDef[p.key]) {
+          if (!this.lang[p.key]) {
             return null;
           }
           const decoration: DecorationOptions = {
@@ -59,7 +60,7 @@ export class UmircDecoration implements Disposable {
                 fontStyle: 'normal',
                 textDecoration: 'none',
                 margin: '0',
-                contentText: ` \u22C5 ${umircDef[p.key]}`,
+                contentText: ` \u22C5 ${this.lang[p.key]}`,
               },
             },
             range: document.validateRange(

--- a/src/language/umircDecoration/index.ts
+++ b/src/language/umircDecoration/index.ts
@@ -1,0 +1,117 @@
+import { Service, Inject } from 'typedi';
+import {
+  Disposable,
+  window,
+  workspace,
+  TextEditor,
+  ThemeColor,
+  Range,
+  DecorationOptions,
+} from 'vscode';
+import { basename } from 'path';
+
+import { isNotNull } from '../../common/utils';
+import { IUmircParser, UmircParserToken } from '../../services/parser/umircParser';
+
+import umircDef from './umircDef';
+
+@Service()
+export class UmircDecoration implements Disposable {
+  private umircParser: IUmircParser;
+  private activeEditor: TextEditor | undefined;
+
+  private annotationDecoration = window.createTextEditorDecorationType({});
+
+  private disposables: Array<Disposable> = [];
+
+  constructor(
+    @Inject(UmircParserToken)
+    umircParser: IUmircParser
+  ) {
+    this.umircParser = umircParser;
+
+    this.init();
+  }
+
+  dispose() {
+    this.disposables.forEach(d => d.dispose());
+  }
+
+  async triggerUpdateDecorations() {
+    if (!this.validUmirc(this.activeEditor)) {
+      return;
+    }
+
+    try {
+      const umiProperties = await this.umircParser.parseFile(this.activeEditor.document.fileName);
+
+      const decorations: Array<DecorationOptions> = umiProperties
+        .map(p => {
+          if (!this.activeEditor || !umircDef[p.key]) {
+            return null;
+          }
+          const decoration: DecorationOptions = {
+            renderOptions: {
+              after: {
+                color: new ThemeColor('umipro.annotationColor'),
+                fontWeight: 'normal',
+                fontStyle: 'normal',
+                textDecoration: 'none',
+                margin: '0',
+                contentText: ` \u22C5 ${umircDef[p.key]}`,
+              },
+            },
+            range: this.activeEditor.document.validateRange(
+              new Range(
+                p.loc.start.line - 1,
+                Number.MAX_SAFE_INTEGER,
+                p.loc.start.line - 1,
+                Number.MAX_SAFE_INTEGER
+              )
+            ),
+          };
+          return decoration;
+        })
+        .filter(isNotNull);
+
+      this.activeEditor.setDecorations(this.annotationDecoration, decorations);
+    } catch (error) {
+      console.warn('error', error);
+    }
+  }
+
+  private validUmirc(editor: TextEditor | undefined): editor is TextEditor {
+    if (!editor) {
+      return false;
+    }
+    const { fileName } = editor.document;
+    if (basename(fileName).includes('.umirc')) {
+      return true;
+    }
+    return fileName.endsWith('config/config.js') || fileName.endsWith('config/config.ts');
+  }
+
+  private init() {
+    this.activeEditor = window.activeTextEditor;
+    if (this.validUmirc(this.activeEditor)) {
+      this.triggerUpdateDecorations();
+    }
+
+    this.disposables.push(
+      window.onDidChangeActiveTextEditor(editor => {
+        this.activeEditor = editor;
+        if (this.validUmirc(this.activeEditor)) {
+          this.triggerUpdateDecorations();
+        }
+      })
+    );
+
+    this.disposables.push(
+      workspace.onDidChangeTextDocument(event => {
+        if (this.validUmirc(this.activeEditor) && event.document === this.activeEditor.document) {
+          this.triggerUpdateDecorations();
+        }
+      })
+    );
+  }
+}

--- a/src/language/umircDecoration/umircDef.ts
+++ b/src/language/umircDecoration/umircDef.ts
@@ -1,0 +1,58 @@
+export default {
+  chainWebpack: 'Extend or modify the webpack configuration via the API of webpack-chain',
+  context: 'Configuring a global context will override the context in each page',
+  disableRedirectHoist: 'whether to disable redirect hoist. false by default',
+  exportStatic:
+    'If set to true or Object, all routes are exported as static pages, otherwise only one index.html is output by default',
+  outputPath: 'Specifies the output path',
+  runtimePublicPath: 'Use the window.publicPath specified in the HTML when the value is true',
+  cssPublicPath: 'Specify an extra publicPath for CSS',
+  minimizer: 'Which minimizer to use. UglifyJS does not support es6 while terser does',
+  hash: 'Whether to enable the hash file suffix',
+  mock: 'Specify config for mock',
+
+  singular: 'If set to true, enable the directory for singular mode',
+  treeShaking: 'Configure whether to enable treeShaking, which is off by default',
+
+  base:
+    'Specify the base of the react-router to be configured when deploying to a non-root directory',
+  history: 'Specify the history type, including browser, hash and memory',
+  mountElementId: 'Specifies the mount point id which the react app will mount to',
+  targets:
+    'Configuring the minimum version of browsers you want to compatible with, umi will automatically introduce polyfill and transform grammar',
+  theme:
+    'The configuration theme is actually equipped with the less variable. Support for both object and string types, the string needs to point to a file that returns the configuration',
+  define:
+    "Passed to the code via the webpack's DefinePlugin , the value is automatically handled by JSON.stringify",
+  externals: 'Configure the externals property of webpack. such as',
+  alias: 'Configure the resolve.alias property of webpack',
+  devServer: 'Configure the devServer property of webpack',
+  devtool: 'Configure the devtool property of webpack',
+  disableCSSModules: 'Disable CSS Modules',
+  disableCSSSourceMap: 'Disable SourceMap generation for CSS',
+  extraBabelPresets: 'Define an additional babel preset list in the form of an array',
+  extraBabelPlugins: 'Define an additional babel plugin list in the form of an array',
+  extraBabelIncludes:
+    'Define a list of additional files that need to be babel converted, in the form of an array, and the array item is webpack#Condition',
+  extraPostCSSPlugins: 'Define additional PostCSS plugins in the format of an array',
+  cssModulesExcludes:
+    'The files in the specified project directory do not go css modules, the format is an array, and the items must be css or less files',
+  copy:
+    'Define a list of files that need to be copied simply. The format is an array. The format of the item refers to the configuration of copy-webpack-plugin',
+  proxy:
+    'Configure the proxy property of webpack-dev-server. If you want to proxy requests to other servers',
+  sass:
+    'Configure options for node-sass. Note: The node-sass and sass-loader dependencies need to be installed in the project directory when using sass',
+  manifest:
+    'After configuration, asset-manifest.json will be generated and the option will be passed to https://www.npmjs.com/package/webpack-manifest-plugin',
+  ignoreMomentLocale: 'Ignore the locale file for moment to reduce the size',
+  lessLoaderOptions: 'Additional configuration items for less-loader',
+  cssLoaderOptions:
+    'Additional configuration items for css-loader.Configure the resolve.alias property of webpack',
+  autoprefixer: 'Configuration for autoprefixer',
+  uglifyJSOptions: 'Configuration for uglifyjs-webpack-plugin@1.x',
+  browserslist: 'Configure browserslist to work with babel-preset-env and autoprefixer',
+  plugins:
+    'Specify the plugins. The array item is the path to the plugin and can be an npm dependency, a relative path, or an absolute path',
+  routes: "Configure routing. Umi's routing is based on react-router",
+};

--- a/src/language/umircDecoration/umircDef/en.ts
+++ b/src/language/umircDecoration/umircDef/en.ts
@@ -24,7 +24,7 @@ export default {
     'The configuration theme is actually equipped with the less variable. Support for both object and string types, the string needs to point to a file that returns the configuration',
   define:
     "Passed to the code via the webpack's DefinePlugin , the value is automatically handled by JSON.stringify",
-  externals: 'Configure the externals property of webpack. such as',
+  externals: 'Configure the externals property of webpack',
   alias: 'Configure the resolve.alias property of webpack',
   devServer: 'Configure the devServer property of webpack',
   devtool: 'Configure the devtool property of webpack',

--- a/src/language/umircDecoration/umircDef/index.ts
+++ b/src/language/umircDecoration/umircDef/index.ts
@@ -1,0 +1,12 @@
+import { env } from 'vscode';
+
+import en from './en';
+import zh_cn from './zh_cn';
+
+export function getlang() {
+  const sysLang = env.language.replace('-', '_');
+  if (sysLang === 'en' || sysLang !== 'zh_cn') {
+    return en;
+  }
+  return zh_cn;
+}

--- a/src/language/umircDecoration/umircDef/zh_cn.ts
+++ b/src/language/umircDecoration/umircDef/zh_cn.ts
@@ -1,0 +1,50 @@
+export default {
+  chainWebpack: '通过 webpack-chain 的 API 扩展或修改 webpack 配置',
+  context: '配置全局 context，会覆盖到每个 pages 里的 context',
+  disableRedirectHoist: '禁用 redirect 上提。默认 false',
+  exportStatic: '如果设为 true 或 Object，则导出全部路由为静态页面，否则默认只输出一个 index.html',
+  outputPath: '指定输出路径',
+  runtimePublicPath: '值为 true 时使用 HTML 里指定的 window.publicPath',
+  cssPublicPath: '为 CSS 指定额外的 publicPath',
+  minimizer: '指定代码压缩工具。UglifyJS 不支持 es6 语法，但 terser 支持',
+  hash: '是否开启 hash 文件后缀',
+  mock: '排除 mock 目录下不作 mock 处理的文件',
+
+  singular: '如果设为 true，启用单数模式的目录',
+  treeShaking: '配置是否开启 treeShaking，默认关闭',
+
+  base: '指定 react-router 的 base，部署到非根目录时需要配置',
+  history: '指定 history 类型，可选 browser、hash 和 memory',
+  mountElementId: '指定 react app 渲染到的 HTML 元素 id',
+  targets:
+    '配置浏览器最低版本，会自动引入 polyfill 和做语法转换，配置的 targets 会和合并到默认值，所以不需要重复配置',
+  theme:
+    '配置主题，实际上是配 less 变量。支持对象和字符串两种类型，字符串需要指向一个返回配置的文件',
+  define: '通过 webpack 的 DefinePlugin 传递给代码，值会自动做 JSON.stringify 处理',
+  externals: '配置 webpack 的 externals 属性',
+  alias: '配置 webpack 的 resolve.alias 属性',
+  devServer: '配置 webpack 的 devServer 属性',
+  devtool: '配置 webpack 的 devtool 属性',
+  disableCSSModules: '禁用 CSS Modules',
+  disableCSSSourceMap: '禁用 CSS 的 SourceMap 生成',
+  extraBabelPresets: '定义额外的 babel preset 列表，格式为数组',
+  extraBabelPlugins: '定义额外的 babel plugin 列表，格式为数组',
+  extraBabelIncludes:
+    '定义额外需要做 babel 转换的文件匹配列表，格式为数组，数组项是 webpack#Condition',
+  extraPostCSSPlugins: '定义额外的 PostCSS 插件，格式为数组',
+  cssModulesExcludes: '指定项目目录下的文件不走 css modules，格式为数组，项必须是 css 或 less 文件',
+  copy: '定义需要单纯做复制的文件列表，格式为数组，项的格式参考 copy-webpack-plugin 的配置',
+  proxy: '配置 webpack-dev-server 的 proxy 属性。 如果要代理请求到其他服务器',
+  sass: '配置 node-sass 的选项。注意：使用 sass 时需在项目目录安装 node-sass 和 sass-loader 依赖',
+  manifest:
+    '配置后会生成 asset-manifest.json，option 传给 https://www.npmjs.com/package/webpack-manifest-plugin',
+  ignoreMomentLocale: '忽略 moment 的 locale 文件，用于减少尺寸',
+  lessLoaderOptions: '给 less-loader 的额外配置项',
+  cssLoaderOptions: '给 css-loader 的额外配置项',
+  autoprefixer: '配置传给 autoprefixer 的配置项',
+  uglifyJSOptions: '配置传给 uglifyjs-webpack-plugin@1.x 的配置项',
+  browserslist: '配置 browserslist，同时作用域 babel-preset-env 和 autoprefixer',
+  plugins:
+    '配置插件列表。数组项为指向插件的路径，可以是 npm 依赖、相对路径或绝对路径。如果是相对路径，则会从项目根目录开始找',
+  routes: '配置路由。umi 的路由基于 react-router 实现，配置和 react-router@4 基本一致',
+};

--- a/src/services/parser/umircParser.ts
+++ b/src/services/parser/umircParser.ts
@@ -1,0 +1,91 @@
+import { VscodeServiceToken, IVscodeService } from './../vscodeService';
+import { IUmirc } from '../../common/types';
+import { isNotNull } from '../../common/utils';
+import * as fs from 'mz/fs';
+import * as babelParser from '@babel/parser';
+
+import { Service, Token, Inject } from 'typedi';
+
+import {
+  isExportDefaultDeclaration,
+  isObjectExpression,
+  ExportDefaultDeclaration,
+  isTSAsExpression,
+  ObjectProperty,
+  SpreadElement,
+  ObjectMethod,
+  isObjectMethod,
+  isObjectProperty,
+} from '@babel/types';
+
+export interface IUmircParser {
+  parseFile(path: string): Promise<IUmirc[]>;
+}
+
+export const UmircParserToken = new Token<IUmircParser>();
+
+@Service(UmircParserToken)
+// eslint-disable-next-line @typescript-eslint/class-name-casing
+class _UmircParser implements IUmircParser {
+  public readonly vscodeService: IVscodeService;
+
+  constructor(
+    @Inject(VscodeServiceToken)
+    vscodeService: IVscodeService
+  ) {
+    this.vscodeService = vscodeService;
+  }
+
+  public async parseFile(path: string): Promise<IUmirc[]> {
+    const code = await fs.readFile(path, 'utf-8');
+    const config = this.vscodeService.getConfig(path);
+    if (!config) {
+      return [];
+    }
+    const ast = babelParser.parse(code, config.parserOptions);
+    const exportDefaultDeclaration = ast.program.body.find((n): n is ExportDefaultDeclaration =>
+      isExportDefaultDeclaration(n)
+    );
+    if (!exportDefaultDeclaration) {
+      return [];
+    }
+    const defaultDeclaration = exportDefaultDeclaration.declaration;
+    const umircAst = isTSAsExpression(defaultDeclaration)
+      ? defaultDeclaration.expression
+      : defaultDeclaration;
+
+    if (!isObjectExpression(umircAst)) {
+      return [];
+    }
+
+    return umircAst.properties.map(p => this.parseProperty(p)).filter((p): p is IUmirc => !!p);
+  }
+
+  private parseProperty(prop: ObjectMethod | ObjectProperty | SpreadElement): IUmirc | null {
+    if (isObjectMethod(prop)) {
+      const { key, start, end, loc } = prop;
+      if (isNotNull(key) && isNotNull(start) && isNotNull(end) && isNotNull(loc)) {
+        return {
+          key: key.name,
+          start: start,
+          end: end,
+          loc: loc,
+        };
+      }
+      return null;
+    }
+    if (isObjectProperty(prop)) {
+      const { key, start, end, loc } = prop;
+      if (isNotNull(key) && isNotNull(start) && isNotNull(end) && isNotNull(loc)) {
+        return {
+          key: key.name,
+          start: start,
+          end: end,
+          loc: loc,
+        };
+      }
+      return null;
+    }
+    return null;
+  }
+}

--- a/src/test/service/parser/umircParser.test.ts
+++ b/src/test/service/parser/umircParser.test.ts
@@ -1,0 +1,100 @@
+import { UmircParserToken } from './../../../services/parser/umircParser';
+import { VscodeServiceToken, loadVscodeService } from '../../../services/vscodeService';
+import assert = require('assert');
+import { join } from 'path';
+import { getAbsPath } from '../../../common/utils';
+import { Container } from 'typedi';
+
+describe('umircParser', async () => {
+  const umircParser = Container.get(UmircParserToken);
+  const vscodeService = Container.get(VscodeServiceToken);
+  await loadVscodeService(vscodeService);
+  const workspaceFixtures = getAbsPath(join(__dirname, '../../fixtures'));
+  const antdPro = join(workspaceFixtures, 'ant-design-pro-master');
+
+  it('test ', async () => {
+    const expectResult = [
+      {
+        key: 'plugins',
+        start: 1768,
+        end: 1775,
+        loc: { start: { line: 64, column: 2 }, end: { line: 64, column: 9 } },
+      },
+      {
+        key: 'define',
+        start: 1779,
+        end: 2017,
+        loc: { start: { line: 65, column: 2 }, end: { line: 68, column: 3 } },
+      },
+      {
+        key: 'treeShaking',
+        start: 2021,
+        end: 2038,
+        loc: { start: { line: 69, column: 2 }, end: { line: 69, column: 19 } },
+      },
+      {
+        key: 'targets',
+        start: 2042,
+        end: 2068,
+        loc: { start: { line: 70, column: 2 }, end: { line: 72, column: 3 } },
+      },
+      {
+        key: 'devtool',
+        start: 2072,
+        end: 2153,
+        loc: { start: { line: 73, column: 2 }, end: { line: 73, column: 83 } },
+      },
+      {
+        key: 'routes',
+        start: 2167,
+        end: 2185,
+        loc: { start: { line: 75, column: 2 }, end: { line: 75, column: 20 } },
+      },
+      {
+        key: 'theme',
+        start: 2263,
+        end: 2310,
+        loc: { start: { line: 78, column: 2 }, end: { line: 80, column: 3 } },
+      },
+      {
+        key: 'ignoreMomentLocale',
+        start: 2494,
+        end: 2518,
+        loc: { start: { line: 88, column: 2 }, end: { line: 88, column: 26 } },
+      },
+      {
+        key: 'lessLoaderOptions',
+        start: 2522,
+        end: 2575,
+        loc: { start: { line: 89, column: 2 }, end: { line: 91, column: 3 } },
+      },
+      {
+        key: 'disableRedirectHoist',
+        start: 2579,
+        end: 2605,
+        loc: { start: { line: 92, column: 2 }, end: { line: 92, column: 28 } },
+      },
+      {
+        key: 'cssLoaderOptions',
+        start: 2609,
+        end: 3354,
+        loc: { start: { line: 93, column: 2 }, end: { line: 114, column: 3 } },
+      },
+      {
+        key: 'manifest',
+        start: 3358,
+        end: 3392,
+        loc: { start: { line: 115, column: 2 }, end: { line: 117, column: 3 } },
+      },
+      {
+        key: 'chainWebpack',
+        start: 3397,
+        end: 3424,
+        loc: { start: { line: 119, column: 2 }, end: { line: 119, column: 29 } },
+      },
+    ];
+    const configPath = join(antdPro, 'config/config.js');
+    const umircs = await umircParser.parseFile(configPath);
+    assert.deepEqual(umircs, expectResult);
+  });
+});


### PR DESCRIPTION
Feature request from [#26](https://github.com/umijs/vscode-extension-umi-pro/issues/26).

Now, if you open `.umirc.js`, `.umirc.ts`, `config/config.js`, `config/config.ts`, you will see property explanation right after it as bellow:

![Screen Shot 2019-06-14 at 12 33 42 PM](https://user-images.githubusercontent.com/1059956/59483765-6e204c00-8ea1-11e9-9b89-96aba9d4c48f.png)
